### PR TITLE
Hotfix Elon Fix + Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ ENABLE_SHARE_LINK: true
 SPOTIFY_CLIENT_ID: "Provide Own"
 SPOTIFY_CLIENT_SECRET: "Provide Own"
 
+# Converter Settings
+ENABLE_MEDIA_LINK_CONVERTER: true
+
 # Misc Settings
 ```
 

--- a/cogs/mediaconverter.py
+++ b/cogs/mediaconverter.py
@@ -34,7 +34,7 @@ class MediaConverter(CommandBase):
 
     @Cog.listener()
     async def on_reaction_add(self, reaction: Reaction, user: User):
-        if reaction.emoji != "📹" or user.bot:
+        if reaction.emoji != "📹" or user.bot or reaction.count > 2:
             return
 
         message = reaction.message

--- a/cogs/mediaconverter.py
+++ b/cogs/mediaconverter.py
@@ -18,15 +18,20 @@ class MediaConverter(CommandBase):
             return
 
         link_info = self.extract_link(message.content)
-        if link_info[0] is "tiktok":
-            embedded_video = self.embed_tiktok(link_info[1])
-            await message.edit(
-                suppress_embeds=True
-            )  # Removes previous embed from context message
-            await message.channel.send(f"[TikTok Link]({embedded_video})")
-        elif link_info[0] is "twitter":
-            converted_link = self.convert_twitter_link(link_info[1])
-            await message.channel.send(f"[Converted Twitter Link]({converted_link})")
+        if link_info:
+            description = ""
+            if link_info[0] == "tiktok":
+                embedded_video = self.embed_tiktok(link_info[1])
+                description = f"[TikTok Link]({embedded_video})"
+            elif link_info[0] == "twitter":
+                converted_link = self.convert_twitter_link(link_info[1])
+                description = f"[Converted Twitter Link]({converted_link})"
+                
+            if description:     # Added this check to avoid an error about sending empty messages
+                await message.edit(
+                    suppress_embeds=True
+                )  # Removes previous embed from context message
+                await message.reply(content=description, mention_author=False)
 
     @classmethod
     def extract_link(cls, text: str):


### PR DESCRIPTION
Close re-open #42 

- Added clause into example YAML file on README
- Optimized some code, now media checkers will return a formatted string containing the converted hyperlink, which will then be used by the await statements at the end
- added a check to ensure that `description` is valid, not adding a check produces a warning, not really an error but it's a quick check just to ensure everything runs without clogging the log.
- changed response to actually reply to the original sender instead of just sending a corresponding message in the chat.  better tracking

Error Below:
```
Ignoring exception in on_message
Traceback (most recent call last):
  File "C:\Users\chai\Desktop\man-chan\venv\lib\site-packages\disnake\client.py", line 703, in _run_event
    await coro(*args, **kwargs)
  File "C:\Users\chai\Desktop\man-chan\cogs\mediaconverter.py", line 32, in on_message
    await message.reply(content=description, mention_author=False)
  File "C:\Users\chai\Desktop\man-chan\venv\lib\site-packages\disnake\message.py", line 2117, in reply
    return await self.channel.send(content, reference=reference, **kwargs)
  File "C:\Users\chai\Desktop\man-chan\venv\lib\site-packages\disnake\abc.py", line 1748, in send
    data = await state.http.send_message(
  File "C:\Users\chai\Desktop\man-chan\venv\lib\site-packages\disnake\http.py", line 415, in request
    raise HTTPException(response, data)
disnake.errors.HTTPException: 400 Bad Request (error code: 50006): Cannot send an empty message
Traceback (most recent call last):
```