### PR TITLE
42 x listener converter

### DIFF
--- a/cogs/mediaconverter.py
+++ b/cogs/mediaconverter.py
@@ -38,8 +38,8 @@ class MediaConverter(CommandBase):
             reaction.emoji != "📹"
             or user.bot
             or reaction.count > 2
-            or not self.extract_link(reaction.message.content)
-        ):
+            or self.extract_link(reaction.message.content)[0] != 'twitter'
+        ): # Added additional checks
             return
 
         message = reaction.message

--- a/cogs/mediaconverter.py
+++ b/cogs/mediaconverter.py
@@ -34,10 +34,18 @@ class MediaConverter(CommandBase):
 
     @Cog.listener()
     async def on_reaction_add(self, reaction: Reaction, user: User):
-        if reaction.emoji != "📹" or user.bot or reaction.count > 2:
+        if (
+            reaction.emoji != "📹"
+            or user.bot
+            or reaction.count > 2
+            or not self.extract_link(reaction.message.content)
+        ):
             return
 
         message = reaction.message
+        if not message.embeds:
+            await message.reply(content="Dickhead this already sent")
+            return  # this assumes that the message embeds have already been surpressed.
         link = self.convert_twitter_link(message.content)
         await message.edit(suppress_embeds=True)
         await message.reply(content=f"[Twitter Link]({link})", mention_author=False)

--- a/cogs/mediaconverter.py
+++ b/cogs/mediaconverter.py
@@ -44,7 +44,6 @@ class MediaConverter(CommandBase):
 
         message = reaction.message
         if not message.embeds:
-            await message.reply(content="Dickhead this already sent")
             return  # this assumes that the message embeds have already been surpressed.
         link = self.convert_twitter_link(message.content)
         await message.edit(suppress_embeds=True)

--- a/cogs/mediaconverter.py
+++ b/cogs/mediaconverter.py
@@ -38,8 +38,8 @@ class MediaConverter(CommandBase):
             reaction.emoji != "📹"
             or user.bot
             or reaction.count > 2
-            or self.extract_link(reaction.message.content)[0] != 'twitter'
-        ): # Added additional checks
+            or self.extract_link(reaction.message.content)[0] != "twitter"
+        ):  # Added additional checks
             return
 
         message = reaction.message
@@ -56,7 +56,7 @@ class MediaConverter(CommandBase):
             text,
         )
         tiktok_match = re.search(
-            r"https?://(?:www\.)?tiktok\.com/[a-zA-Z0-9_]+/[a-zA-Z0-9_]+",
+            r"https?://(?:www\.)?tiktok\.com/(?:@[a-zA-Z0-9_]+|[a-zA-Z0-9_]+)/(?:[a-zA-Z0-9_]+|video/\d+)(?:\S+)?",
             text,
         )
         if twitter_match:
@@ -83,8 +83,7 @@ class MediaConverter(CommandBase):
     @classmethod
     def embed_tiktok(cls, tiktok_link: Optional[str]):
         if tiktok_link:
-            data = {"input_text": tiktok_link}
-
+            data = {"input_text": tiktok_link, "detailed": False}
             response = requests.post(
                 "https://api.quickvids.win/v1/shorturl/create", json=data
             ).json()


### PR DESCRIPTION
title.

Added additional check to `on_reaction_add` to see if link is a valid one
- Remembered that manny would probably read the pr initially, see that i only check to see if it's a valid link, then try to exploit it with a tiktok link

in later logic, assuming it passes EVERYTHING else, checks to see if the message (which would presumably be a twitter link at this point) has any additional embeds. Initial conversion would suppress all of it's original embeds turning `message.embeds` into an empty list.  If the embeds are empty, clear it, there's no need to convert anything nor clear it. 

Reacting with an emoji to something with an embed or a converted fxtwitter link shouldn't work either, cause it wouldn't clear the initial if statement