### PR TITLE
Plugin Commands Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ Example: !choose pizza, chicken and waffles, burger
 > chicken and waffles
 ```
 
+### **Plugins**
+Allows you to load exterior commands outside of the main functionality.
+List these under a `/plugins` folder.
+
+For example, let's say you have two github repos with sets of commands that are compatible with ManChan bot: `images` and `encoder`.
+
+Add those to the plugins folder like so:
+`/plugins/image/generator.py`
+`/plugins/image/formatter.py`
+`/plugins/encoder/encode.py`
+
+Each of those modules will be loaded like any other Cog.
+
 ## Coming soon:
 ### **Money Ledger**
 Keep track of what each person owes money too. Useful for social events where one person pays for everyone and stuff.

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,1 @@
+from .command_loader import *

--- a/bot/command_loader.py
+++ b/bot/command_loader.py
@@ -1,0 +1,48 @@
+from os import listdir
+from os.path import isdir
+from os.path import join as osjoin
+import logging
+
+from typing import Generator, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from utils.distyping import ManChanBot
+
+
+class CommandLoader:
+    _exclusion = {"__init__.py", "base.py"}
+
+    def __init__(self, bot: "ManChanBot"):
+        self._bot = bot
+
+    def refresh_commands(self):
+        logging.info("Loading commands...")
+        for cog in self._get_available_cogs():
+            self.add_command(cog)
+
+        logging.info("Loading plugins commands...")
+        for plugins in self._get_available_plugins():
+            self.add_command(plugins)
+
+    def add_command(self, command: str):
+        logging.info(f"Loading module {command}")
+        # This will run setup() on each Cog module it loads.
+        self._bot.load_extension(command)
+
+    def _get_available_cogs(self) -> Generator[str, None, None]:
+        for file in listdir("cogs"):
+            if self._is_valid_file(file):
+                yield self._format_file_name(file, "cogs")
+
+    def _get_available_plugins(self) -> Generator[str, None, None]:
+        for folder in listdir("plugins"):
+            if isdir(osjoin("plugins", folder)):
+                for file in listdir(osjoin("plugins", folder)):
+                    if self._is_valid_file(file):
+                        yield self._format_file_name(file, f"plugins.{folder}")
+
+    def _is_valid_file(self, file: str) -> bool:
+        return file.endswith(".py") and file not in CommandLoader._exclusion
+
+    def _format_file_name(self, file: str, dis_path: str) -> str:
+        return f"{dis_path}.{file[:-3]}"

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -22,7 +22,7 @@ class Fun(CommandBase):
     @command()
     async def choose(self, ctx: Context, *args: str):
         # Will randomly choose a selection of words delimited by commas
-        options = "".join(args).split(",")
+        options = " ".join(args).split(",")
         await ctx.channel.send(random.choice(options).strip())
 
 

--- a/db/base.py
+++ b/db/base.py
@@ -9,7 +9,6 @@ from .connection import get_session
 
 
 class Base(object):
-
     id = Column(Integer, autoincrement=True, primary_key=True)
 
     def __init__(self, **kwargs: Any):
@@ -34,7 +33,7 @@ class Base(object):
         return base
 
     @classmethod
-    def _query(cls, entities: List[Any] = []) -> Query:
+    def _query(cls, entities: List[Any] = []) -> "Query[Any]":
         """
         Creates a query object from session.
 

--- a/fmt.py
+++ b/fmt.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
     # Formatting
     print("-- Formatting... --")
     try:
-        print(main(["main.py", "cogs", "db", "utils", "service", "fetcher"]))
+        print(main(["main.py", "bot", "cogs", "db", "fetcher", "utils", "service"]))
     except:
         pass
 
@@ -20,6 +20,6 @@ if __name__ == "__main__":
     os.system("pyright")
 
     print("-- Checking imports... --")
-    os.system("isort -c main.py cogs db utils --profile black")
+    os.system("isort -c main.py bot cogs db utils --profile black")
 
     print("Done!")

--- a/main.py
+++ b/main.py
@@ -1,11 +1,10 @@
 import asyncio
 import logging
-from os import listdir
-from typing import Generator
 
 from disnake import Game, Intents
 from disnake.ext.commands import Bot
 
+from bot.command_loader import CommandLoader
 from db.connection import DatabaseException, setup_db_session
 from utils.yaml_loader import load_yaml
 
@@ -26,6 +25,9 @@ class ManChanBot(Bot):
         asyncio.run(self._prepare_bot())
 
     async def on_ready(self):
+        """
+        Disnake function called when startup is finished
+        """
         logging.info(f"{self.user.name} has connected to Discord!")
         if self.configs.get("PRESENCE_TEXT"):
             await self.change_presence(
@@ -42,8 +44,8 @@ class ManChanBot(Bot):
         logging.info("Preparing database connection...")
         self._setup_db()
 
-        logging.info("Loading commands...")
-        await self._load_commands()
+        # Loading the cog and plugin commands
+        CommandLoader(self).refresh_commands()
 
         logging.info("Booting up ManChan-gelions...")
 
@@ -55,7 +57,7 @@ class ManChanBot(Bot):
         # Check if essential Discord settings exist
         if len(configs) <= 0:
             raise ValueError(
-                "Nothing in the configs.yaml was loaded!; Cannot start bot."
+                "Nothing in the configs.yaml was loaded! Cannot start bot."
             )
 
         if "DISCORD_TOKEN" not in configs:
@@ -75,6 +77,9 @@ class ManChanBot(Bot):
 
     def _setup_db(self):
         if "DATABASE_URL" not in self.configs:
+            # Will always start bot without a database unless given an
+            # env variable to not start without it.
+            # Properly check database conditions on Cogs that require it.
             if self.configs.get("FORCE_DATABASE", True):
                 raise DatabaseException("No database was provided")
             logging.warning(
@@ -87,18 +92,6 @@ class ManChanBot(Bot):
         setup_db_session(self.configs["DATABASE_URL"])
         self.db_on = True
         self.configs["db_on"] = self.db_on
-
-    async def _load_commands(self):
-        for module in self._iterate_modules():
-            logging.info(f"Loading module {module}")
-            # This will run setup() on each Cog module it loads.
-            self.load_extension(module)  # type: ignore
-
-    def _iterate_modules(self) -> Generator:
-        for file in listdir("cogs"):
-            if file.endswith(".py") and file not in {"__init__.py", "base.py"}:
-                file_name = file[:-3]
-                yield f"cogs.{file_name}"
 
     def _generate_intents(self):
         intents = Intents.all()

--- a/service/login/login_base.py
+++ b/service/login/login_base.py
@@ -20,7 +20,7 @@ class LoginBase(ServiceBase):
         super().__init__(ctx, configs)
 
     @property
-    def logins(self) -> Dict[str, Dict]:
+    def logins(self) -> Dict[str, Dict[str, Any]]:
         return self._logins
 
     @logins.setter

--- a/service/login/login_info.py
+++ b/service/login/login_info.py
@@ -43,7 +43,7 @@ class LoginInfo(LoginBase):
 
 class _LoginPageInteraction(CallbackBase):
     @property
-    def logins(self) -> Dict[str, Dict]:
+    def logins(self) -> Dict[str, Dict[str, Any]]:
         return cast(LoginInfo, self.service).logins
 
     @property

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -2,7 +2,7 @@ from re import search
 from typing import Optional, Tuple
 
 
-def hex_to_rgb(hex: str) -> Optional[Tuple[int, int, int]]:
+def hex_to_rgb(hex: str) -> Optional[Tuple[int, ...]]:
     if hex is None or len(hex) < 6:
         return None
 

--- a/utils/yaml_loader.py
+++ b/utils/yaml_loader.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Any, cast
 
 from yaml import Loader, load
 
@@ -7,7 +7,7 @@ class YamlReadError(Exception):
     pass
 
 
-def load_yaml() -> dict:
+def load_yaml() -> dict[str, Any]:
     configs = {}
     with open("./configs.yaml", "r", encoding="utf-8") as file:
         configs = load(file, Loader)


### PR DESCRIPTION
Added support to load commands exterior from the main functionality. These must be placed under the `/plugins` folder, each with their own folder.

For example:

`/plugins/image/generator.py`
`/plugins/image/formatter.py`
`plugins/encoder/encode.py`

The `image` folder would be its own subset group of commands (think of it as some github repo) with two classes that each have commands. The `encoder` is another subset group.