### PR TITLE
Username ReGex Hotfix to include periods

### DIFF
--- a/cogs/mediaconverter.py
+++ b/cogs/mediaconverter.py
@@ -56,7 +56,7 @@ class MediaConverter(CommandBase):
             text,
         )
         tiktok_match = re.search(
-            r"https?://(?:www\.)?tiktok\.com/(?:@[a-zA-Z0-9_]+|[a-zA-Z0-9_]+)/(?:[a-zA-Z0-9_]+|video/\d+)(?:\S+)?",
+            r"https?://(?:www\.)?tiktok\.com/(?:@[a-zA-Z0-9_.]+|[a-zA-Z0-9_]+)/(?:[a-zA-Z0-9_]+|video/\d+)(?:\S+)?",
             text,
         )
         if twitter_match:


### PR DESCRIPTION
...i forgot to account that some usernames may also have periods in them.  I double checked TikTok username documentation to see what was allowed in a username.

https://support.tiktok.com/en/getting-started/setting-up-your-profile/changing-your-username

* Usernames can only contain letters, numbers, underscores, and periods. However, periods can't be added to the end of a username.

New Regex: `@[a-zA-Z0-9_.]+`
